### PR TITLE
Import EF: remove dedup so all source rows are kept

### DIFF
--- a/src/controller/emissionFactorController.ts
+++ b/src/controller/emissionFactorController.ts
@@ -77,13 +77,20 @@ function normHeader(h: string): string {
 }
 
 // Map normalized header -> canonical field. gwp is matched by prefix below.
+// Both the human labels ("Group", "Sub-category") and the raw DB column names
+// ("group_name", "sub_category") are accepted — normHeader strips punctuation,
+// so "group_name" -> "groupname" and "sub_category" -> "subcategory".
 const HEADER_TO_FIELD: Record<string, FieldKey> = {
     domain: "domain",
     category: "category",
     subcategory: "sub_category",
+    subcategoryname: "sub_category",
     group: "group_name",
+    groupname: "group_name",
     specifictype: "specific_type",
+    specifictypename: "specific_type",
     geography: "geography",
+    country: "geography",
     unit: "unit",
 };
 
@@ -366,9 +373,9 @@ export async function importEmissionFactorsCsv(req: any, res: any) {
             return res.status(400).send({ success: false, message: "CSV contained no data rows" });
         }
 
-        // Atomic replace: wipe + bulk insert in one transaction. ON CONFLICT
-        // DO NOTHING absorbs in-file duplicates that would collide on the
-        // (domain, specific_type, geography, unit) dedup constraint.
+        // Atomic replace: wipe + bulk insert in one transaction. Every source
+        // row is inserted verbatim — NO dedup — so the row count always matches
+        // the file exactly (ef_id is auto-assigned, so identical rows are fine).
         let insertedCount = 0;
         await withClient(async (client: any) => {
             await client.query("BEGIN");
@@ -389,7 +396,6 @@ export async function importEmissionFactorsCsv(req: any, res: any) {
                     const sql = `
                         INSERT INTO emission_factors (${DB_COLUMNS.join(",")})
                         VALUES ${placeholders.join(",")}
-                        ON CONFLICT (domain, specific_type, geography, unit) DO NOTHING
                     `;
                     const r = await client.query(sql, params);
                     insertedCount += r.rowCount ?? 0;

--- a/src/models/migrationbatch.ts
+++ b/src/models/migrationbatch.ts
@@ -3741,10 +3741,10 @@ ADD COLUMN IF NOT EXISTS ef_code VARCHAR(255);
             search_text    TEXT,
             source_db      TEXT DEFAULT 'BAFU 2025',
             created_at     TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-            updated_at     TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-            CONSTRAINT uq_emission_factors_dedup
-                UNIQUE (domain, specific_type, geography, unit)
+            updated_at     TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
         );`,
+        // NOTE: no UNIQUE/dedup constraint — every source row is imported
+        // verbatim so the row count always matches the file exactly (10,305).
 
         // --- Indexes ---
         // Unit hard-gate lookup (domain + unit) — the primary access path.


### PR DESCRIPTION
The unique (domain, specific_type, geography, unit) constraint + ON CONFLICT DO NOTHING was silently skipping ~928 rows whose specific_type collided, leaving 9,377 of 10,305. Drop the constraint and use a plain INSERT so the imported row count always matches the file exactly. ef_id (BIGSERIAL) keeps every row uniquely addressable.